### PR TITLE
Improve README for both frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,34 @@
 # Zer0mind
 
-This project contains the React front‑end for the Zer0mind prototype. The UI is built using **Vite** and **Tailwind CSS** with various Radix UI and Chakra components. The codebase lives in the `src/` directory and provides both the public site and an extensive admin panel under `src/pages/admin`.
+Zer0mind is an experimental admin panel built with **React**, **Vite** and **Tailwind CSS**.  The frontend lives in this directory while the FastAPI backend resides in `python backend/`.
 
-The admin interface includes pages for agents, flows, tools, prompts, plans and more. All communication with the backend is centralized in `src/services/api.js`, which exposes small helper functions for authentication, agent management and other REST endpoints.
+## Project structure
 
+- `src/` – React application
+- `src/pages/admin` – admin dashboard
+- `python backend/` – FastAPI API (see its [README](python%20backend/README.md))
 
+## Requirements
 
-Running the script will execute each agent and print their responses.
+- Node.js 20 (see `.nvmrc`)
+- A running instance of the backend
 
-## Front‑end setup
+## Setup
+
+1. Copy `.env` and adjust `VITE_API_BASE_URL` to point to your backend.
+2. Install dependencies:
 
 ```bash
 npm install
+```
+
+3. Start the development server:
+
+```bash
 npm run dev
 ```
 
-The dev server proxies API requests to `http://localhost:8000` as configured in `vite.config.js`.
+The dev server proxies API requests to `http://localhost:8000` by default.  Build for production with `npm run build`.
 
-## Python requirements
-
-Below are the packages required to run `exampleagent.py` and the (now removed) FastAPI backend:
-
-```text
-fastapi==0.110.1
-uvicorn[standard]==0.29.0
-sqlalchemy==2.0.30
-alembic==1.13.1
-pydantic>=2.10.0,<3.0.0
-pydantic-settings>=2.0.0
-python-dotenv==1.0.1
-httpx==0.27.0
-passlib[bcrypt]==1.7.4
-python-jose[cryptography]>=3.3.0
-aiofiles==23.2.1
-python-multipart==0.0.9
-fastapi[all]==0.110.1
-openai-agents==0.0.17
-loguru==0.7.2
-pymongo>=4.3.3
-motor>=3.1.1
-fastapi>=0.68.0
-uvicorn>=0.15.0
-python-multipart>=0.0.5
-```
-
-These dependencies can be installed with `pip install -r requirements.txt` if such a file is recreated from the list above.
+For backend instructions see [`python backend/README.md`](python%20backend/README.md).
 

--- a/python backend/README.md
+++ b/python backend/README.md
@@ -1,3 +1,36 @@
-# Project documentation
+# Zer0mind Backend
+
+FastAPI server that powers the Zer0mind admin panel.
+
+## Requirements
+
+- Python 3.10+
+- MongoDB accessible via `MONGO_URI`
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Create a `.env` file with at least:
+
+```env
+MONGO_URI=mongodb://localhost:27017
+OPENAI_API_KEY=sk-...
+JWT_SECRET=super-secret-key
+ACCESS_TOKEN_EXPIRE_MINUTES=1440
+```
+
+## Running
+
+Start the API using Uvicorn:
+
+```bash
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-Step 6: Editing handoff conditions (branch logic) in FlowBuilder.jsx
+```
+
+The server exposes routes under `/api` and will initialise MongoDB collections on startup.
+


### PR DESCRIPTION
## Summary
- flesh out setup instructions for frontend
- add dedicated instructions for backend API

## Testing
- `python -m compileall -q 'python backend/app'`

------
https://chatgpt.com/codex/tasks/task_e_684c95deb464832ebfae8fcfc3d30424